### PR TITLE
Fix license-name property to include '+'

### DIFF
--- a/IEWarn/extension.json
+++ b/IEWarn/extension.json
@@ -6,7 +6,7 @@
     "description": "Adds a warning when a user is using Internet Explorer or Microsoft Edge.",
     "descriptionmsg": "iewarn-desc",
     "version": "1.0",
-    "license-name": "AGPL-3.0",
+    "license-name": "AGPL-3.0+",
     "requires": {
         "MediaWiki": ">= 1.25.0"
     },


### PR DESCRIPTION
IEWarnHooks.php says version 3 or later, so the correct SPDX license
identifier is AGPL-3.0+.